### PR TITLE
Rewrite README to reflect Nix-Darwin and Home Manager setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,20 @@
 # My personal dotfiles
 This is a collection of my dotfiles.
 
-> [!NOTE]
-> This doc is out of date and needs to be rewritten. The repo is now using Nix-Darwin and Home Manager instead of GNU Stow.
-
 ## Usage
 
-Clone this repository to your home directory (`~/dotfiles`), then run `stow` to symlink the dotfiles you want to use.
+Clone this repository to your home directory (`~/dotfiles`), then run `darwin-rebuild` to apply the configuration.
 
-For example, to symlink the `vim` dotfiles, run:
+For example, to apply the configuration, run:
 
 ```shell
 cd ~/dotfiles
-stow zsh
+darwin-rebuild switch --flake .#client-Tim-Shilov
 ```
 
 ## Brew usage
 
 ```shell
-cd brew
-
 # install everything
 brew bundle
 
@@ -32,4 +27,6 @@ brew bundle cleanup
 
 ## Requirements
 
-- [GNU Stow](https://www.gnu.org/software/stow/)
+- [Nix](https://nixos.org/)
+- [Nix-Darwin](https://github.com/LnL7/nix-darwin)
+- [Home Manager](https://github.com/nix-community/home-manager)


### PR DESCRIPTION
Update `README.md` to reflect the current setup with Nix-Darwin and Home Manager instead of GNU Stow.

* **Usage Instructions**
  - Replace instructions for using GNU Stow with instructions for using `darwin-rebuild`.
  - Update example command to use `darwin-rebuild switch --flake .#client-Tim-Shilov`.

* **Brew Usage**
  - Remove unnecessary `cd brew` command.

* **Requirements**
  - Remove GNU Stow from the requirements.
  - Add Nix, Nix-Darwin, and Home Manager to the requirements.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TimShilov/.dotfiles?shareId=XXXX-XXXX-XXXX-XXXX).