### PR TITLE
Fix LSP autocommand error on file save after re-running LSP

### DIFF
--- a/modules/home-manager/dotfiles/nvim/lua/plugins/lsp.lua
+++ b/modules/home-manager/dotfiles/nvim/lua/plugins/lsp.lua
@@ -61,6 +61,18 @@ return { -- LSP Configuration & Plugins
           command = 'silent! EslintFixAll',
           group = vim.api.nvim_create_augroup('ESlintFixAll', {}),
         })
+
+        -- Autocommand to clear existing LSP clients before re-running LSP
+        vim.api.nvim_create_autocmd('LspRestart', {
+          group = vim.api.nvim_create_augroup('LspRestartGroup', { clear = true }),
+          callback = function()
+            local clients = vim.lsp.get_active_clients()
+            for _, client in ipairs(clients) do
+              vim.lsp.stop_client(client.id)
+            end
+            vim.cmd('LspStart')
+          end,
+        })
       end,
     })
 


### PR DESCRIPTION
Add an autocommand to clear existing LSP clients before re-running LSP.

* Add a new autocommand `LspRestart` to clear existing LSP clients before re-running LSP.
* Use `vim.lsp.stop_client` to stop all active LSP clients.
* Restart the LSP clients after stopping them by running `LspStart`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TimShilov/.dotfiles/pull/30?shareId=88942f10-915b-4671-850c-be8c9ace3a27).